### PR TITLE
Service Provider fixed for missing parameter

### DIFF
--- a/src/MailServiceProvider.php
+++ b/src/MailServiceProvider.php
@@ -32,7 +32,7 @@ class MailServiceProvider extends CoreMailServiceProvider {
 			// Once we have create the mailer instance, we will set a container instance
 			// on the mailer. This allows us to resolve mailer classes via containers
 			// for maximum testability on said classes instead of passing Closures.
-			$mailer = new Mailer($app['view'], $app['swift.mailer']);
+			$mailer = new Mailer($app['view'], $app['swift.mailer'], $app['events']);
 
 			$mailer->setLogger($app['log'])->setQueue($app['queue']);
 


### PR DESCRIPTION
I fixed it for Laravel 4.2. It was perfectly sending signed mails on 4.2 before the fix and now after the fix events are back like the stock registered Mailer. I hope reset of testing would be fine.
